### PR TITLE
Possibility to set a custom _id

### DIFF
--- a/src/gridFS_server.coffee
+++ b/src/gridFS_server.coffee
@@ -220,7 +220,7 @@ if Meteor.isServer
          callback = share.bind_env callback
          cbCalled = false
          mods = {}
-         mods._id = file._id if file._id
+         mods._id = file._id if file._id?
          mods.filename = file.filename if file.filename?
          mods.aliases = file.aliases if file.aliases?
          mods.contentType = file.contentType if file.contentType?

--- a/src/gridFS_server.coffee
+++ b/src/gridFS_server.coffee
@@ -96,7 +96,9 @@ if Meteor.isServer
 
                # Make darn sure we're creating a valid gridFS .files document
                check file,
-                  _id: Mongo.ObjectID
+                  _id: Match.Where (x) => 
+                     check x, Mongo.ObjectID
+                     x is Mongo.ObjectID()
                   length: Match.Where (x) =>
                      check x, Match.Integer
                      x is 0
@@ -218,6 +220,7 @@ if Meteor.isServer
          callback = share.bind_env callback
          cbCalled = false
          mods = {}
+         mods._id = file._id if file._id
          mods.filename = file.filename if file.filename?
          mods.aliases = file.aliases if file.aliases?
          mods.contentType = file.contentType if file.contentType?


### PR DESCRIPTION
Hi, this is rather a question than an issue. But it would solve some troubles on my end, what i'm interested in is this line 
https://github.com/vsivsi/meteor-file-collection/blob/master/src/gridFS_server.coffee#L99

Can we have a Match.Where here and check if _id is already a valid Mongo.ObjectId and only create a new id if it isn't? Something like in this pull? 

(Please correct the code if there's a need, i'm not used to coffeescript)