### PR TITLE
Upgrade to v2 of coffee

### DIFF
--- a/package.js
+++ b/package.js
@@ -4,7 +4,7 @@
 ###     See included LICENSE file for details.
 ***************************************************************************/
 
-var currentVersion = '1.3.8';
+var currentVersion = '2.0.0';
 
 Package.describe({
   summary: 'Collections that efficiently store files using MongoDB GridFS, with built-in HTTP support',
@@ -27,7 +27,7 @@ Npm.depends({
 });
 
 Package.onUse(function(api) {
-  api.use('coffeescript@1.12.3_1', ['server','client']);
+  api.use('coffeescript@2.0.3_3', ['server','client']);
   api.use('webapp@1.3.13', 'server');
   api.use('mongo@1.1.15', ['server', 'client']);
   api.use('minimongo@1.0.20', 'server');
@@ -45,7 +45,7 @@ Package.onUse(function(api) {
 
 Package.onTest(function (api) {
   api.use('vsivsi:file-collection@' + currentVersion, ['server', 'client']);
-  api.use('coffeescript@1.12.3_1', ['server', 'client']);
+  api.use('coffeescript@2.0.3_3', ['server', 'client']);
   api.use('tinytest@1.0.12', ['server', 'client']);
   api.use('test-helpers@1.0.11', ['server','client']);
   api.use('http@1.2.11', ['server','client']);

--- a/src/gridFS_client.coffee
+++ b/src/gridFS_client.coffee
@@ -8,24 +8,26 @@ if Meteor.isClient
 
    class FileCollection extends Mongo.Collection
 
-      constructor: (@root = share.defaultRoot, options = {}) ->
+      constructor: (root, options = {}) ->
+         unless Mongo.Collection is Mongo.Collection.prototype.constructor
+           throw new Meteor.Error 'The global definition of Mongo.Collection has been patched by another package, and the prototype constructor has been left in an inconsistent state. Please see this link for a workaround: https://github.com/vsivsi/meteor-file-sample-app/issues/2#issuecomment-120780592'
+
+         if typeof root is 'object'
+            options = root
+            root = share.defaultRoot
+
+         super root + '.files', { idGeneration: 'MONGO' }
+
          unless @ instanceof FileCollection
             return new FileCollection(root, options)
 
          unless @ instanceof Mongo.Collection
             throw new Meteor.Error 'The global definition of Mongo.Collection has changed since the file-collection package was loaded. Please ensure that any packages that redefine Mongo.Collection are loaded before file-collection.'
 
-         unless Mongo.Collection is Mongo.Collection.prototype.constructor
-           throw new Meteor.Error 'The global definition of Mongo.Collection has been patched by another package, and the prototype constructor has been left in an inconsistent state. Please see this link for a workaround: https://github.com/vsivsi/meteor-file-sample-app/issues/2#issuecomment-120780592'
-
-         if typeof @root is 'object'
-            options = @root
-            @root = share.defaultRoot
-
+         @root = root
          @base = @root
          @baseURL = options.baseURL ? "/gridfs/#{@root}"
          @chunkSize = options.chunkSize ? share.defaultChunkSize
-         super @root + '.files', { idGeneration: 'MONGO' }
 
          # This call sets up the optional support for resumable.js
          # See the resumable.coffee file for more information

--- a/src/gridFS_client.coffee
+++ b/src/gridFS_client.coffee
@@ -8,7 +8,7 @@ if Meteor.isClient
 
    class FileCollection extends Mongo.Collection
 
-      constructor: (root, options = {}) ->
+      constructor: (root = share.defaultRoot, options = {}) ->
          unless Mongo.Collection is Mongo.Collection.prototype.constructor
            throw new Meteor.Error 'The global definition of Mongo.Collection has been patched by another package, and the prototype constructor has been left in an inconsistent state. Please see this link for a workaround: https://github.com/vsivsi/meteor-file-sample-app/issues/2#issuecomment-120780592'
 

--- a/src/gridFS_server.coffee
+++ b/src/gridFS_server.coffee
@@ -265,7 +265,7 @@ if Meteor.isServer
                writeStream.on 'expires-soon', () =>
                   writeStream.renewLock (e, d) ->
                      if e or not d
-                        console.warn "Automatic Write Lock Renewal Failed: #{file._id.str}", e
+                        console.warn "Automatic Write Lock Renewal Failed: #{file._id._str}", e
 
             if callback?
                writeStream.on 'close', (retFile) ->

--- a/test/file_collection_tests.coffee
+++ b/test/file_collection_tests.coffee
@@ -499,7 +499,7 @@ createContent = (_id, data, name, chunkNum, chunkSize = 16) ->
     Content-Disposition: form-data; name="resumableIdentifier"\r
     Content-Type: text/plain\r
     \r
-    #{_id}\r
+    #{_id._str}\r
     --AaB03x\r
     Content-Disposition: form-data; name="resumableFilename"\r
     Content-Type: text/plain\r
@@ -529,7 +529,7 @@ createCheckQuery = (_id, data, name, chunkNum, chunkSize = 16) ->
   throw new Error "Bad chunkNum" if chunkNum > totalChunks
   begin = (chunkNum - 1) * chunkSize
   end = if chunkNum is totalChunks then data.length else chunkNum * chunkSize
-  "?resumableChunkNumber=#{chunkNum}&resumableChunkSize=#{chunkSize}&resumableCurrentChunkSize=#{end-begin}&resumableTotalSize=#{data.length}&resumableType=text/plain&resumableIdentifier=#{_id}&resumableFilename=#{name}&resumableRelativePath=#{name}&resumableTotalChunks=#{totalChunks}"
+  "?resumableChunkNumber=#{chunkNum}&resumableChunkSize=#{chunkSize}&resumableCurrentChunkSize=#{end-begin}&resumableTotalSize=#{data.length}&resumableType=text/plain&resumableIdentifier=#{_id._str}&resumableFilename=#{name}&resumableRelativePath=#{name}&resumableTotalChunks=#{totalChunks}"
 
 Tinytest.addAsync 'Basic resumable.js REST interface POST/GET/DELETE', (test, onComplete) ->
   testColl.insert { filename: 'writeresumablefile', contentType: 'text/plain' }, (err, _id) ->
@@ -858,7 +858,7 @@ if Meteor.isClient
     testColl.resumable.on 'fileAdded', (file) ->
       testColl.insert { _id: file.uniqueIdentifier, filename: file.fileName, contentType: file.file.type }, (err, _id) ->
         test.fail(err) if err
-        thisId = "#{_id}"
+        thisId = "#{_id._str}"
         testColl.resumable.upload()
 
     testColl.resumable.on 'fileSuccess', (file) ->
@@ -885,7 +885,7 @@ if Meteor.isClient
     testColl.resumable.on 'fileAdded', (file) ->
       testColl.insert { _id: file.uniqueIdentifier, filename: file.fileName, contentType: file.file.type }, (err, _id) ->
         test.fail(err) if err
-        thisId = "#{_id}"
+        thisId = "#{_id._str}"
         testColl.resumable.upload()
 
     testColl.resumable.on 'fileSuccess', (file) ->


### PR DESCRIPTION
Make meteor-file-collection work with V2 of Coffescript (specifically 2.0.3.3).

### Changes to `package.js`
- I make the project dependent upon `coffeescript@2.0.3_3`.
- I reset the version of `vsivsi:meteor-file-collection` to `2.0.0`. Because of the dependency on `coffeescript@2.0.3_3`.

I believe all changes are backward compatible with v1 of CoffeeScript.  But I did not retest them.

## 3 areas needed to be addressed:

### [`super` and `this`](http://coffeescript.org/#breaking-changes-super-this)

Needed to refactor the FileCollection class constructor for both client and server.

### `FileCollection.__super__` does not exist
Simply set `FileCollection.__super__` to `Mongo.Collection.prototype`

### String interpolations behave differently
In v1 a string interpolation for an `ObjectID` would resolve to the string portion of the object e.g. the `_str` property.  This is no longer the case with v2.